### PR TITLE
Feature: Merge additional properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,5 @@ Derefs <code>$ref</code>'s in JSON Schema to actual resolved values. Supports lo
 | options | <code>Object</code> | options |
 | options.baseFolder | <code>String</code> | the base folder to get relative path files from. Default is <code>process.cwd()</code> |
 | options.failOnMissing | <code>Boolean</code> | By default missing / unresolved refs will be left as is with their ref value intact.                                        If set to <code>true</code> we will error out on first missing ref that we cannot                                        resolve. Default: <code>false</code>. |
+| options.mergeAdditionalProperties | <code>Boolean</code> | By default properties in a object with $ref will be removed in the output.                                                    If set to <code>true</code> they will be added/overwrite the ouput. |
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -240,10 +240,10 @@ function derefSchema (schema, options, state) {
           this.update(node, options.failOnMissing)
         } else {
           if (options.mergeAdditionalProperties) {
-            delete node.$ref;
+            delete node.$ref
             newValue = Object.assign({}, newValue, node)
           }
-          this.update(newValue);
+          this.update(newValue)
           if (state.missing.indexOf(refVal) !== -1) {
             state.missing.splice(state.missing.indexOf(refVal), 1)
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -262,7 +262,7 @@ function derefSchema (schema, options, state) {
  *                                        If set to <code>true</code> we will error out on first missing ref that we cannot
  *                                        resolve. Default: <code>false</code>.
  * @param {Boolean} options.mergeAdditionalProperties - By default properties in a object with $ref will be removed in the output.
- *                                                    If set to <code>true</code> they will be added/overwrite the ouput.
+ *                                                    If set to <code>true</code> they will be added/overwrite the output.
  *                                                    Default: <code>false</code>.
  * @return {Object|Error} the deref schema oran instance of <code>Error</code> if error.
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -261,6 +261,9 @@ function derefSchema (schema, options, state) {
  * @param {Boolean} options.failOnMissing - By default missing / unresolved refs will be left as is with their ref value intact.
  *                                        If set to <code>true</code> we will error out on first missing ref that we cannot
  *                                        resolve. Default: <code>false</code>.
+ * @param {Boolean} options.mergeAdditionalProperties - By default properties in a object with $ref will be removed in the output.
+ *                                                    If set to <code>true</code> they will be added/overwrite the ouput.
+ *                                                    Default: <code>false</code>.
  * @return {Object|Error} the deref schema oran instance of <code>Error</code> if error.
  */
 function deref (schema, options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -228,7 +228,7 @@ function derefSchema (schema, options, state) {
         this.update(node, true)
       } else {
         setCurrent(state, refType, refVal)
-        const newValue = getRefSchema(refVal, refType, schema, options, state)
+        let newValue = getRefSchema(refVal, refType, schema, options, state)
         state.history.pop()
         if (newValue === undefined) {
           if (state.missing.indexOf(refVal) === -1) {
@@ -239,7 +239,11 @@ function derefSchema (schema, options, state) {
           }
           this.update(node, options.failOnMissing)
         } else {
-          this.update(newValue)
+          if (options.mergeAdditionalProperties) {
+            delete node.$ref;
+            newValue = Object.assign({}, newValue, node)
+          }
+          this.update(newValue);
           if (state.missing.indexOf(refVal) !== -1) {
             state.missing.splice(state.missing.indexOf(refVal), 1)
           }


### PR DESCRIPTION
By default properties in a object with $ref will be removed in the output.

If set to `true` they will be added/overwrite the output.

Default: `false`.

If you don't want this feature, just close this PR. This feature does not comply with the json schema spec http://json-schema.org/latest/json-schema-core.html#rfc.section.8.3

```
All other properties in a "$ref" object MUST be ignored.
```